### PR TITLE
bugfix to frictionless resulting from conversion (builder.py) script

### DIFF
--- a/variable-level-metadata-schema/build.py
+++ b/variable-level-metadata-schema/build.py
@@ -45,7 +45,7 @@ def select_specs(items,schema,specname="_csvSpec"):
     #loop through schema
     schema_selected = {}
     for key,item in items.items():
-        if key==specname:
+        if key==specname or key+"s"==specname or key==specname+"s": #allow plural of Spec
             spec = item
             schema_selected.update(spec)
         elif re.search("^_.*Spec$",key):

--- a/variable-level-metadata-schema/schemas/frictionless/fields.json
+++ b/variable-level-metadata-schema/schemas/frictionless/fields.json
@@ -1,0 +1,234 @@
+{
+  "description": "Variable level metadata individual fields integrated into the variable level\nmetadata object within the HEAL platform metadata service.\n",
+  "title": "HEAL Variable Level Metadata Fields",
+  "fields": [
+    {
+      "name": "module",
+      "description": "Module (a place to put the section, form, or other broad category used \nto group variables.\n",
+      "title": "Module (i.e., section,form,category)",
+      "examples": [
+        "Demographics",
+        "PROMIS",
+        "Substance use",
+        "Medical History",
+        "Sleep questions",
+        "Physical activity"
+      ],
+      "type": "string"
+    },
+    {
+      "name": "name",
+      "description": "The name of a variable (i.e., field) as it appears in the data.\n",
+      "title": "Variable Name",
+      "type": "string",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "title",
+      "description": "The human-readable title of the variable.",
+      "title": "Variable Label (ie Title)",
+      "type": "string"
+    },
+    {
+      "name": "description",
+      "description": "An extended description of the variable.",
+      "title": "Variable Description",
+      "examples": [
+        "Definition",
+        "Question text (if a survey)"
+      ],
+      "type": "string",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "type",
+      "description": "A classification allowing the user (analyst, researcher or computer) to\nknow how to use the variable\n",
+      "title": "Variable Type",
+      "type": "string",
+      "constraints": {
+        "enum": [
+          "duration",
+          "string",
+          "geopoint",
+          "boolean",
+          "number",
+          "yearmonth",
+          "year",
+          "datetime",
+          "date",
+          "time",
+          "integer",
+          "any"
+        ]
+      }
+    },
+    {
+      "name": "format",
+      "description": "Indicates the format of the type specified in the `type` property. This\nmay describe the type of unit (such as for time fields like year or month)\nor the format of a date field (such as %y%m%d).\n",
+      "title": "Variable Format",
+      "type": "string",
+      "constraints": {
+        "enum": [
+          "binary",
+          "uuid",
+          "uri",
+          "object",
+          "email",
+          "topojson",
+          "array",
+          "any"
+        ]
+      }
+    },
+    {
+      "name": "constraints.maxLength",
+      "description": "Indicates the maximum length of an iterable (e.g., array, string, or\nobject). For example, if 'Hello World' is the longest value of a\ncategorical variable, this would be a maxLength of 11.\n",
+      "title": "Maximum Length",
+      "type": "integer"
+    },
+    {
+      "name": "constraints.enum",
+      "description": "Constrains possible values to a set of values.",
+      "title": "Variable Possible Values",
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:[^|]+\\||[^|]*)(?:[^|]*\\|)*[^|]*$"
+      }
+    },
+    {
+      "name": "constraints.pattern",
+      "description": "A regular expression pattern the data MUST conform to.",
+      "title": "Regular Expression Pattern",
+      "type": "string"
+    },
+    {
+      "name": "constraints.maximum",
+      "description": "Specifies the maximum value of a field (e.g., maximum -- or most\nrecent -- date, maximum integer etc). Note, this is different then\nmaxLength property.\n",
+      "title": "Maximum Value",
+      "type": "integer"
+    },
+    {
+      "name": "encodings",
+      "description": "Encodings (and mappings) allow categorical values to be stored as\nnumerical values. IMPORTANT: the ==key should be the value represented IN\nthe data== and the ==value should be the to-be-mapped label==. Many\nanalytic software programs use numerical encodings and some algorithms\nonly support numerical values. Additionally, this field provides a way to\nstore categoricals that are stored as  \"short\" labels (such as\nabbreviations)\n",
+      "title": "Variable Value Encodings (i.e., mappings; value labels)",
+      "examples": [
+        "0=No|1=Yes",
+        "HW=Hello world|GBW=Good bye world|HM=Hi,Mike"
+      ],
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:.*?=.*?(?:\\||$))+$"
+      }
+    },
+    {
+      "name": "ordered",
+      "description": "Indicates whether a categorical variable is ordered. This variable  is\nrelevant for variables that have an ordered relationship but not\nnecessarily  a numerical relationship (e.g., Strongly disagree < Disagree\n< Neutral < Agree).\n",
+      "title": "An ordered variable",
+      "type": "boolean"
+    },
+    {
+      "name": "missingValues",
+      "description": "A list of missing values specific to a variable.",
+      "title": "Missing Values",
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:[^|]+\\||[^|]*)(?:[^|]*\\|)*[^|]*$"
+      }
+    },
+    {
+      "name": "trueValues",
+      "description": "For boolean (true) variable (as defined in type field), this field allows\na physical string representation to be cast as true (increasing\nreadability of the field). It can include one or more values.\n",
+      "title": "Boolean True Value Labels",
+      "examples": [
+        "Required|REQUIRED",
+        "required|Yes|Y|Checked",
+        "Checked",
+        "Required"
+      ],
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:[^|]+\\||[^|]*)(?:[^|]*\\|)*[^|]*$"
+      }
+    },
+    {
+      "name": "falseValues",
+      "description": "For boolean (false) variable (as defined in type field), this field allows\na physical string representation to be cast as false (increasing\nreadability of the field) that is not a standard false value. It can include one or more values.\n",
+      "title": "Boolean False Value Labels",
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:[^|]+\\||[^|]*)(?:[^|]*\\|)*[^|]*$"
+      }
+    },
+    {
+      "name": "repo_link",
+      "description": "A link to the variable as it exists on the home repository, if applicable\n",
+      "title": "Variable Repository Link",
+      "type": "string"
+    },
+    {
+      "name": "cde_id",
+      "description": "The source and id for the NIH Common Data Elements program.",
+      "title": "Common Data Element Id",
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:.*?=.*?(?:\\||$))+$"
+      }
+    },
+    {
+      "name": "ontology_id",
+      "description": "Ontological information for the given variable as indicated  by the\nsource, id, and relation to the specified classification. One or more\nontology classifications can be specified. \n",
+      "title": "Ontology ID",
+      "type": "string",
+      "constraints": {
+        "pattern": "^(?:[^|=]*=){3}(?:[^|]*\\|[^|=]*=){2}[^|]*=(?:[^|]*\\|)?$"
+      }
+    },
+    {
+      "name": "univar_stats.median",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.mean",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.std",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.min",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.max",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.mode",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.count",
+      "type": "integer"
+    },
+    {
+      "name": "univar_stats.twenty_five_percentile",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.seventy_five_percentile",
+      "type": "number"
+    },
+    {
+      "name": "univar_stats.cat_marginals",
+      "type": "array"
+    }
+  ],
+  "missingValues": [
+    ""
+  ]
+}


### PR DESCRIPTION
"_xxxSpec(s)" keys in dictionary yaml file (now identifies either *Specs or *Spec). Was resulting in the specific (json or csv) specs not being pulled. 

